### PR TITLE
[setup.py] Add an setup script for users to run pip3 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ An energy estimation plug-in for [Accelergy framework](https://github.com/nellie
 
 ## Use the plug-in
 - Clone the repo by ```git clone https://github.com/nelliewu95/accelergy-aladdin-plug-in.git```
-- Open Accelergy's config file ```accelergy_config.yaml``` and add a new list item that points to the cloned folder
+- Option 1
+    - Run ```pip3 install .``` and use the same arguments as installing Accelergy
+- Option 2
+    - Open Accelergy's config file ```accelergy_config.yaml``` and add a new list item that points to the cloned folder
 - To set the relative accuracy of your Aladdin plug-in
     - open ```aladdin_table.py``` 
     - Edit the first line to set the ```ALADDIN_ACCURACY``` (default is 70)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+from setuptools import setup
+import os
+
+def readme():
+      with open('README.md') as f:
+            return f.read()
+
+setup(
+      name='accelergy-aladdin-plug-in',
+      version='0.1',
+      description='An energy estimation plug-in for Accelergy framework',
+      classifiers=[
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
+      ],
+      keywords='accelerator hardware energy estimation aladdin',
+      author='Yannan Wu',
+      author_email='nelliewu@mit.edu',
+      license='MIT',
+      install_requires = ['pyYAML'],
+      python_requires = '>=3.6',
+      data_files=[
+                  ('share/accelergy/estimation_plug_ins/accelergy-aladdin-plug-in',
+                    ['aladdin.estimator.yaml',
+                     'aladdin_table.py']),
+                  ('share/accelergy/estimation_plug_ins/accelergy-aladdin-plug-in/data',
+                    ['data/adder.csv',
+                     'data/bitwise.csv',
+                     'data/fp_dp_adder.csv',
+                     'data/fp_dp_multiplier.csv',
+                     'data/fp_sp_adder.csv',
+                     'data/fp_sp_multiplier.csv',
+                     'data/multiplier.csv',
+                     'data/reg.csv',
+                     'data/shifter.csv']),
+                  ],
+      include_package_data = True,
+      entry_points = {},
+      zip_safe = False,
+    )


### PR DESCRIPTION
This lets user to run "pip3 install ." to install this plug-in directly
under the default location: $prefix/share/accelergy/estimation_plug_ins/